### PR TITLE
Enhance cross-platform compatibility for server script execution in package.json

### DIFF
--- a/r3/package.json
+++ b/r3/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "server": "python3 server/app.py",
+    "server": "cross-env PYTHON=python3 node src/serverRunner.js",
     "dev": "run-p server start",
     "build": "react-scripts build",
     "test": "react-scripts test",
@@ -43,5 +43,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.3"
   }
 }

--- a/r3/src/serverRunner.js
+++ b/r3/src/serverRunner.js
@@ -1,0 +1,20 @@
+const { execSync } = require("child_process");
+const isWindows = process.platform === "win32";
+
+try {
+  // Try running with python3
+  execSync("python3 server/app.py", { stdio: "inherit" });
+} catch (error) {
+  if (isWindows) {
+    // If on Windows, try running with python
+    try {
+      execSync("python server/app.py", { stdio: "inherit" });
+    } catch (error) {
+      console.error("Error running server:", error);
+      process.exit(1);
+    }
+  } else {
+    console.error("Error running server:", error);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
addresses cross-platform compatibility concerns related to running the server script. Now it doesn't matter if you use python3 vs python, should work for both.

Changes made:

- Modified serverRunner.js to first attempt running the server script with python3.

- Added a fallback for Windows environments, where it tries running with python if python3 fails.

- Improved error handling and provided meaningful error messages.

- Changed server script to "cross-env PYTHON=python3 node src/serverRunner.js"

for new dependency:
npm install --save-dev cross-env