### PR TITLE
Skip move/loading screen

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -51,7 +51,7 @@ def run_astar():
     global current_cargo_state
     global steps
     global currStep
-    print("APP.PY: run astar called")
+
     currStep = 0
 
     # 1. Extract data from request
@@ -62,19 +62,19 @@ def run_astar():
 
     # 1.2 Reformat from list of strings to list of Containers
     loadReformat: List[Container] = []
-    print(f'load before formatting: {load}')
+    #print(f'load before formatting: {load}')
     for i in range(0, len(load), 2):
         loadReformat.append( Container(info=(load[i], load[i+1])) )
     current_cargo_state.load = loadReformat
 
-    print(f'Offload before astar: {current_cargo_state.offload}')
+    #print(f'Offload before astar: {current_cargo_state.offload}')
 
     # 2. Run astar
     solution, steps = search.astar(current_cargo_state, is_balance)
 
     # 2.2 Reformat moves from list of Move objects to list of Move-like dictionaries
     movesReformat: List[Dict[str, List[int]|int]] = []
-    print(f'moves before formatting: {steps}')
+    #print(f'moves before formatting: {steps}')
     for move in steps:
         temp = {
             'name': move.src.container.name, 
@@ -122,7 +122,7 @@ def run_move():
     global current_cargo_state
     global steps
     global currStep
-    print("APP.PY: runmove called")
+
     # only make the move if we have moves left
     if (currStep < len(steps)):
         move_data = steps[currStep]
@@ -146,10 +146,8 @@ def run_move():
 
         # Check if the move is for a container in the offload or load list then update the corresponding list if so
         if move_data['next-area'] == 2: # the destination for the container is a truck
-            print("APP.PY: popped from offload")
             current_cargo_state.offload.remove(src_con.name) # pop the container from the offload list with the same name as the container in the move
         elif move_data['current-area'] == 2: # the source for the container is a truck
-            print("APP.PY: popped from load")
             current_cargo_state.load.remove(src_con)
     # todo: make it so that it logs a message here should be incredibly simple
 

--- a/server/app.py
+++ b/server/app.py
@@ -93,90 +93,27 @@ def run_astar():
 
     # 3. return the goal state, moves, and the step you are currently on to frontend (will always be 0 since you are just running the algorithm)
     return jsonify({"solution": solution.val.toDict(), "moves": steps, "currStep": currStep })
-
+    
 @app.route('/skip-move', methods=['POST'])
 def skip_move(): 
     global current_cargo_state 
     global steps 
     global currStep 
-    print("offload", current_cargo_state.offload)
-    print("onload", current_cargo_state.load)
-    deleteStep = steps[currStep] # the step to delete from either load/offload list 
-    deleteContainer = Container(info=(deleteStep['name'], deleteStep['weight'])) 
-    if current_cargo_state: 
-        print(current_cargo_state.load)
-        print(current_cargo_state.offload)
-        if deleteStep['next-area'] == 2: # the destination for the container is a truck
-            print("APP.PY: popped from offload")
-            current_cargo_state.offload.remove(deleteContainer.name) # pop the container from the offload list with the same name as the container in the move
-        elif deleteStep['current-area'] == 2: # the source for the container is a truck
-            print("APP.PY: popped from load")
-            current_cargo_state.load.remove(deleteContainer)
-    solution, steps = search.astar(current_cargo_state, False)
-    currStep = 0
-    
-    # 2.2 Reformat moves from list of Move objects to list of Move-like dictionaries
-    movesReformat: List[Dict[str, List[int]|int]] = []
-    print(f'moves before formatting: {steps}')
-    for move in steps:
-        temp = {
-            'name': move.src.container.name, 
-            'current-grid-position': [move.src.row+1, move.src.col+1],
-            'current-area': move.src.area,
-            'next-grid-position': [move.dst.row+1, move.dst.col+1],
-            'next-area': move.dst.area,
-            'cost': move.cost(), 
-            'weight': move.src.container.weight,
-            'description': str(move), 
-        }
-        movesReformat.append(temp)
-    steps = movesReformat
-    # 3. return the goal state, moves, and the step you are currently on to frontend (will always be 0 since you are just running the algorithm)
-    return jsonify({"solution": solution.val.toDict(), "moves": steps, "currStep": currStep })
-    
-@app.route('/skip-move2', methods=['POST'])
-def skip_move2(): 
-    global current_cargo_state 
-    global steps 
-    global currStep 
-    print("APP.PY: skipmove 2 called")
-    print("APP.PY: offload", current_cargo_state.offload)
-    print("APP.PY: onload", current_cargo_state.load)
+
     deleteStep = steps[currStep] # the step to delete from either load/offload list 
     deleteContainer = Container(info=(deleteStep['name'], deleteStep['weight'])) 
     if current_cargo_state: 
         if deleteStep['next-area'] == 2: # the destination for the container is a truck
-            print("APP.PY: popped from offload")
             current_cargo_state.offload.remove(deleteContainer.name) # pop the container from the offload list with the same name as the container in the move
         elif deleteStep['current-area'] == 2: # the source for the container is a truck
-            print("APP.PY: popped from load")
             current_cargo_state.load.remove(deleteContainer)
-    #solution, steps = search.astar(current_cargo_state, False)
-    currStep = 0
-    
-    # 2.2 Reformat moves from list of Move objects to list of Move-like dictionaries
-    # movesReformat: List[Dict[str, List[int]|int]] = []
-    # print(f'moves before formatting: {steps}')
-    # for move in steps:
-    #     temp = {
-    #         'name': move.src.container.name, 
-    #         'current-grid-position': [move.src.row+1, move.src.col+1],
-    #         'current-area': move.src.area,
-    #         'next-grid-position': [move.dst.row+1, move.dst.col+1],
-    #         'next-area': move.dst.area,
-    #         'cost': move.cost(), 
-    #         'weight': move.src.container.weight,
-    #         'description': str(move), 
-    #     }
-    #     movesReformat.append(temp)
-    # steps = movesReformat
-    # 3. return the goal state, moves, and the step you are currently on to frontend (will always be 0 since you are just running the algorithm)
+
     new_load_list = []
     for container in current_cargo_state.load: 
         new_load_list.append(str(container.name))
         new_load_list.append(str(container.weight))
 
-    return jsonify({"currStep": currStep, "offload": str(current_cargo_state.offload), "load": str(new_load_list) })
+    return jsonify({"offload": (current_cargo_state.offload), "load": (new_load_list) })
 
 
 
@@ -228,8 +165,8 @@ def run_move():
 
     dict = current_cargo_state.toDict()
     dict['currStep'] = currStep
-    dict['offload'] = str(current_cargo_state.offload)
-    dict['load'] = str(new_load_list)
+    dict['offload'] = (current_cargo_state.offload)
+    dict['load'] = (new_load_list)
 
     # return the current cargo state, the step # you are currently on, and the updated offload/load lists
     return jsonify(dict)

--- a/server/app.py
+++ b/server/app.py
@@ -106,14 +106,15 @@ def skip_move():
     if current_cargo_state: 
         print(current_cargo_state.load)
         print(current_cargo_state.offload)
-        if deleteStep['current-area'] == 2: # load operation 
+        if deleteStep['next-area'] == 2: # the destination for the container is a truck
+            print("APP.PY: popped from offload")
+            current_cargo_state.offload.remove(deleteContainer.name) # pop the container from the offload list with the same name as the container in the move
+        elif deleteStep['current-area'] == 2: # the source for the container is a truck
+            print("APP.PY: popped from load")
             current_cargo_state.load.remove(deleteContainer)
-        else: # offload operation 
-            current_cargo_state.offload.remove(deleteContainer.name)
-
-    
     solution, steps = search.astar(current_cargo_state, False)
-
+    currStep = 0
+    
     # 2.2 Reformat moves from list of Move objects to list of Move-like dictionaries
     movesReformat: List[Dict[str, List[int]|int]] = []
     print(f'moves before formatting: {steps}')
@@ -142,8 +143,6 @@ def run_move():
     global current_cargo_state
     global steps
     global currStep
-    global offload
-    global load
     # only make the move if we have moves left
     if (currStep < len(steps)):
         move_data = steps[currStep]

--- a/server/app.py
+++ b/server/app.py
@@ -99,10 +99,13 @@ def skip_move():
     global current_cargo_state 
     global steps 
     global currStep 
-
+    print("offload", current_cargo_state.offload)
+    print("onload", current_cargo_state.load)
     deleteStep = steps[currStep] # the step to delete from either load/offload list 
     deleteContainer = Container(info=(deleteStep['name'], deleteStep['weight'])) 
     if current_cargo_state: 
+        print(current_cargo_state.load)
+        print(current_cargo_state.offload)
         if deleteStep['current-area'] == 2: # load operation 
             current_cargo_state.load.remove(deleteContainer)
         else: # offload operation 
@@ -126,7 +129,7 @@ def skip_move():
             'description': str(move), 
         }
         movesReformat.append(temp)
-
+    steps = movesReformat
     # 3. return the goal state, moves, and the step you are currently on to frontend (will always be 0 since you are just running the algorithm)
     return jsonify({"solution": solution.val.toDict(), "moves": steps, "currStep": currStep })
     

--- a/server/app.py
+++ b/server/app.py
@@ -94,6 +94,9 @@ def run_astar():
     # 3. return the goal state, moves, and the step you are currently on to frontend (will always be 0 since you are just running the algorithm)
     return jsonify({"solution": solution.val.toDict(), "moves": steps, "currStep": currStep })
 
+
+
+
 @app.route('/run-move', methods=['POST'])
 def run_move():
     global current_cargo_state
@@ -101,7 +104,6 @@ def run_move():
     global currStep
     global offload
     global load
-
     # only make the move if we have moves left
     if (currStep < len(steps)):
         # get the current move
@@ -130,17 +132,23 @@ def run_move():
             current_cargo_state.offload.remove(src_con.name) # pop the container from the offload list with the same name as the container in the move
         elif move_data['current-area'] == 2: # the source for the container is a truck
             print("APP.PY: popped from load")
-            current_cargo_state.load.remove(src_con) # pop the container from the load list with the same name as the container in the move
-
+            new_load_list = current_cargo_state.load.remove(src_con)
     # todo: make it so that it logs a message here should be incredibly simple
+
+    
+    new_load_list = []
+    for container in current_cargo_state.load: 
+        new_load_list.append(str(container.name))
+        new_load_list.append(str(container.weight))
 
     # we are on the next move now
     currStep += 1
 
+
     dict = current_cargo_state.toDict()
     dict['currStep'] = currStep
     dict['offload'] = str(current_cargo_state.offload)
-    dict['load'] = str(current_cargo_state.load)
+    dict['load'] = str(new_load_list)
 
     # return the current cargo state, the step # you are currently on, and the updated offload/load lists
     return jsonify(dict)

--- a/server/app.py
+++ b/server/app.py
@@ -51,7 +51,7 @@ def run_astar():
     global current_cargo_state
     global steps
     global currStep
-
+    print("APP.PY: run astar called")
     currStep = 0
 
     # 1. Extract data from request
@@ -134,7 +134,49 @@ def skip_move():
     # 3. return the goal state, moves, and the step you are currently on to frontend (will always be 0 since you are just running the algorithm)
     return jsonify({"solution": solution.val.toDict(), "moves": steps, "currStep": currStep })
     
+@app.route('/skip-move2', methods=['POST'])
+def skip_move2(): 
+    global current_cargo_state 
+    global steps 
+    global currStep 
+    print("APP.PY: skipmove 2 called")
+    print("APP.PY: offload", current_cargo_state.offload)
+    print("APP.PY: onload", current_cargo_state.load)
+    deleteStep = steps[currStep] # the step to delete from either load/offload list 
+    deleteContainer = Container(info=(deleteStep['name'], deleteStep['weight'])) 
+    if current_cargo_state: 
+        if deleteStep['next-area'] == 2: # the destination for the container is a truck
+            print("APP.PY: popped from offload")
+            current_cargo_state.offload.remove(deleteContainer.name) # pop the container from the offload list with the same name as the container in the move
+        elif deleteStep['current-area'] == 2: # the source for the container is a truck
+            print("APP.PY: popped from load")
+            current_cargo_state.load.remove(deleteContainer)
+    #solution, steps = search.astar(current_cargo_state, False)
+    currStep = 0
+    
+    # 2.2 Reformat moves from list of Move objects to list of Move-like dictionaries
+    # movesReformat: List[Dict[str, List[int]|int]] = []
+    # print(f'moves before formatting: {steps}')
+    # for move in steps:
+    #     temp = {
+    #         'name': move.src.container.name, 
+    #         'current-grid-position': [move.src.row+1, move.src.col+1],
+    #         'current-area': move.src.area,
+    #         'next-grid-position': [move.dst.row+1, move.dst.col+1],
+    #         'next-area': move.dst.area,
+    #         'cost': move.cost(), 
+    #         'weight': move.src.container.weight,
+    #         'description': str(move), 
+    #     }
+    #     movesReformat.append(temp)
+    # steps = movesReformat
+    # 3. return the goal state, moves, and the step you are currently on to frontend (will always be 0 since you are just running the algorithm)
+    new_load_list = []
+    for container in current_cargo_state.load: 
+        new_load_list.append(str(container.name))
+        new_load_list.append(str(container.weight))
 
+    return jsonify({"currStep": currStep, "offload": str(current_cargo_state.offload), "load": str(new_load_list) })
 
 
 
@@ -143,6 +185,7 @@ def run_move():
     global current_cargo_state
     global steps
     global currStep
+    print("APP.PY: runmove called")
     # only make the move if we have moves left
     if (currStep < len(steps)):
         move_data = steps[currStep]

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import DefaultState from "./components/DefaultState";
 import Login from "./components/Login";
 import Home from "./components/Home";
 import Finish from "./components/Finish"; 
+import Loading from "./components/Loading"; 
 import DockView from "./components/DockView";
 import UploadTransfer from "./components/UploadTransfer";
 

--- a/src/components/BackendRoutes.js
+++ b/src/components/BackendRoutes.js
@@ -118,7 +118,7 @@ const runMove = async (cachedState, setCachedState) => {
 
 const skipMove = async (cachedState, setCachedState) => {
     if (cachedState.opType !== 'Offloading/Onloading') { 
-      throw new Error("Skipping moves is not allowed for load balancing. The ship could tip over!!!\n"); 
+      return; 
     }
   
     try {
@@ -135,7 +135,7 @@ const skipMove = async (cachedState, setCachedState) => {
   
         setCachedState({
           ...cachedState,
-          currStep: 0, 
+          currStep: result.currStep, 
           instruction: makeInstruction(result.currStep, result.moves), 
           moves: result.moves, 
           inProgress: true,

--- a/src/components/BackendRoutes.js
+++ b/src/components/BackendRoutes.js
@@ -100,8 +100,8 @@ const runMove = async (cachedState, setCachedState) => {
         instruction: makeInstruction(result.currStep, cachedState.moves),
         manifest: result.ship,
         buffer: result.buffer,
-        offloadList: JSON.parse(result.offload),
-        loadList: JSON.parse(result.load),
+        offloadList: (result.offload),
+        loadList: (result.load),
       });
 
       localStorage.setItem("manifest", result.shipTxt);
@@ -117,47 +117,12 @@ const runMove = async (cachedState, setCachedState) => {
 };
 
 const skipMove = async (cachedState, setCachedState) => {
-    if (cachedState.opType !== 'Offloading/Onloading') { 
-      return; 
-    }
-  
-    try {
-      const response = await fetch("http://127.0.0.1:5000/skip-move", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        }
-      });
-  
-      if (response.ok) {
-        const result = await response.json();
-        console.log("BACKENDROUTES.JS: ** skip move ** runAstar called ", result);
-  
-        setCachedState({
-          ...cachedState,
-          currStep: result.currStep, 
-          instruction: makeInstruction(result.currStep, result.moves), 
-          moves: result.moves, 
-          inProgress: true,
-          solution: result.solution,  
-        });
-        console.log("BACKENDROUTES.JS: for skip move: ", result); 
-        return result;
-      } else {
-        console.error("Failed to run A* algorithm. Status:", response.status);
-      }
-    } catch (error) {
-      console.error("Error during A* algorithm:", error.message);
-    }
-};
-
-const skipMove2 = async (cachedState, setCachedState) => {
   if (cachedState.opType !== 'Offloading/Onloading') { 
     return; 
   }
 
   try {
-    const response = await fetch("http://127.0.0.1:5000/skip-move2", {
+    const response = await fetch("http://127.0.0.1:5000/skip-move", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -170,11 +135,10 @@ const skipMove2 = async (cachedState, setCachedState) => {
 
       setCachedState({
         ...cachedState,
-        currStep: result.currStep, 
         moves: null, 
         inProgress: false,
-        offloadList: JSON.parse(result.offload),
-        loadList: JSON.parse(result.load),
+        offloadList: (result.offload),
+        loadList: (result.load),
       });
       console.log("BACKENDROUTES.JS: for skip move: ", result); 
       return result;
@@ -258,7 +222,6 @@ export {
   runAstar,
   runMove,
   skipMove,
-  skipMove2,
   handleLogMessage,
   handleCustomLog,
 };

--- a/src/components/BackendRoutes.js
+++ b/src/components/BackendRoutes.js
@@ -116,8 +116,39 @@ const runMove = async (cachedState, setCachedState) => {
   }
 };
 
-const skipMove = async () => {
-  // todo
+const skipMove = async (cachedState, setCachedState) => {
+    if (cachedState.opType !== 'Offloading/Onloading') { 
+      throw new Error("Skipping moves is not allowed for load balancing. The ship could tip over!!!\n"); 
+    }
+  
+    try {
+      const response = await fetch("http://127.0.0.1:5000/skip-move", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        }
+      });
+  
+      if (response.ok) {
+        const result = await response.json();
+        console.log("BACKENDROUTES.JS: ** skip move ** runAstar called ", result);
+  
+        setCachedState({
+          ...cachedState,
+          currStep: 0, 
+          instruction: makeInstruction(result.currStep, result.moves), 
+          moves: result.moves, 
+          inProgress: true,
+          solution: result.solution,  
+        });
+        console.log("BACKENDROUTES.JS: for skip move: ", result); 
+        return result;
+      } else {
+        console.error("Failed to run A* algorithm. Status:", response.status);
+      }
+    } catch (error) {
+      console.error("Error during A* algorithm:", error.message);
+    }
 };
 
 // gets the current move from the moves list passed into it and the step # you are on, then builds an instruction string which is then returned as a string

--- a/src/components/BackendRoutes.js
+++ b/src/components/BackendRoutes.js
@@ -100,8 +100,8 @@ const runMove = async (cachedState, setCachedState) => {
         instruction: makeInstruction(result.currStep, cachedState.moves),
         manifest: result.ship,
         buffer: result.buffer,
-        offloadList: (result.offload),
-        loadList: (result.load),
+        offloadList: result.offload,
+        loadList: result.load,
       });
 
       localStorage.setItem("manifest", result.shipTxt);
@@ -137,8 +137,8 @@ const skipMove = async (cachedState, setCachedState) => {
         ...cachedState,
         moves: null, 
         inProgress: false,
-        offloadList: (result.offload),
-        loadList: (result.load),
+        offloadList: result.offload,
+        loadList: result.load,
       });
       console.log("BACKENDROUTES.JS: for skip move: ", result); 
       return result;

--- a/src/components/BackendRoutes.js
+++ b/src/components/BackendRoutes.js
@@ -100,8 +100,8 @@ const runMove = async (cachedState, setCachedState) => {
         instruction: makeInstruction(result.currStep, cachedState.moves),
         manifest: result.ship,
         buffer: result.buffer,
-        offloadList: result.offload,
-        loadList: result.load,
+        offloadList: JSON.parse(result.offload),
+        loadList: JSON.parse(result.load),
       });
 
       localStorage.setItem("manifest", result.shipTxt);
@@ -149,6 +149,41 @@ const skipMove = async (cachedState, setCachedState) => {
     } catch (error) {
       console.error("Error during A* algorithm:", error.message);
     }
+};
+
+const skipMove2 = async (cachedState, setCachedState) => {
+  if (cachedState.opType !== 'Offloading/Onloading') { 
+    return; 
+  }
+
+  try {
+    const response = await fetch("http://127.0.0.1:5000/skip-move2", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      }
+    });
+
+    if (response.ok) {
+      const result = await response.json();
+      console.log("BACKENDROUTES.JS: ** skip move ** runAstar called ", result);
+
+      setCachedState({
+        ...cachedState,
+        currStep: result.currStep, 
+        moves: null, 
+        inProgress: false,
+        offloadList: JSON.parse(result.offload),
+        loadList: JSON.parse(result.load),
+      });
+      console.log("BACKENDROUTES.JS: for skip move: ", result); 
+      return result;
+    } else {
+      console.error("Failed to skip move. Status:", response.status);
+    }
+  } catch (error) {
+    console.error("Error during skipMove:", error.message);
+  }
 };
 
 // gets the current move from the moves list passed into it and the step # you are on, then builds an instruction string which is then returned as a string
@@ -223,6 +258,7 @@ export {
   runAstar,
   runMove,
   skipMove,
+  skipMove2,
   handleLogMessage,
   handleCustomLog,
 };

--- a/src/components/DefaultState.js
+++ b/src/components/DefaultState.js
@@ -12,7 +12,7 @@ return ({
     buffer: null,
     loadList: [],
     offloadList: [],
-    moves: []
+    moves: null
 }); 
 });
 

--- a/src/components/DockView.js
+++ b/src/components/DockView.js
@@ -5,6 +5,7 @@ import {
   runMove,
   handleCustomLog,
   skipMove,
+  skipMove2,
 } from "./BackendRoutes";
 import Loading from "./Loading"; 
 import Grid from "./Grid";
@@ -81,8 +82,8 @@ export default function DockView ({ cachedState, setCachedState }) {
                 </button>
                 <button
                   onClick={() => {
-                    setCachedState({...cachedState, inProgress: false})
-                    skipMove(cachedState, setCachedState)}}
+                    //setCachedState({...cachedState, inProgress: false})
+                    skipMove2(cachedState, setCachedState)}}
                   className="primary-submit-btn"
                 >
                   Skip Move

--- a/src/components/DockView.js
+++ b/src/components/DockView.js
@@ -17,6 +17,7 @@ export default function DockView ({ cachedState, setCachedState }) {
   const currentCargoState = useRef(cachedState.manifest); 
   const currentBufferState = useRef([]); 
   const goalCargoState = useRef([]);
+  const displayText = ""; 
 
   const currMove = useRef({
     "cost": -1,
@@ -34,12 +35,6 @@ export default function DockView ({ cachedState, setCachedState }) {
   const BUFFER = "buffer";
   const SHIP = "ship";
 
-
-
-  const triggerSkipMove = () => {
-    skipMove(cachedState, setCachedState); 
-    
-  }
 
 
   // runs a star if there wasnt already an operation in progress and cargostate has already been initialized (cachedState.buffer)
@@ -62,7 +57,7 @@ export default function DockView ({ cachedState, setCachedState }) {
   return (
     <div> 
       <LogoutButton setCachedState={setCachedState}/> 
-        {cachedState.buffer && cachedState.moves ? (
+        {cachedState.inProgress ? (
           <div className="dock-view-container">
             <Grid type={SHIP} items={cachedState.manifest} id="ship-dock" />
             <Grid type={BUFFER} items={cachedState.buffer} id="buffer-dock" />
@@ -85,7 +80,9 @@ export default function DockView ({ cachedState, setCachedState }) {
                   Make Move
                 </button>
                 <button
-                  onClick={() => skipMove(cachedState, setCachedState)}
+                  onClick={() => {
+                    setCachedState({...cachedState, inProgress: false})
+                    skipMove(cachedState, setCachedState)}}
                   className="primary-submit-btn"
                 >
                   Skip Move
@@ -100,7 +97,7 @@ export default function DockView ({ cachedState, setCachedState }) {
           </div>
           </div> 
         ) : (
-          <Loading displayText={"Sit tight! We're currently calculating the best moveset..."} /> 
+          <Loading displayText={displayText} /> 
         )}
     </div> 
 )};

--- a/src/components/DockView.js
+++ b/src/components/DockView.js
@@ -6,6 +6,7 @@ import {
   handleCustomLog,
   skipMove,
 } from "./BackendRoutes";
+import Loading from "./Loading"; 
 import Grid from "./Grid";
 import LogoutButton from "./LogoutButton";
 
@@ -59,21 +60,12 @@ export default function DockView ({ cachedState, setCachedState }) {
   
 
   return (
-    <div className="dock-view-container">
+    <div> 
       <LogoutButton setCachedState={setCachedState}/> 
-      <div>
-        {cachedState.buffer ? (
-          <>
+        {cachedState.buffer && cachedState.moves ? (
+          <div className="dock-view-container">
             <Grid type={SHIP} items={cachedState.manifest} id="ship-dock" />
             <Grid type={BUFFER} items={cachedState.buffer} id="buffer-dock" />
-          </>
-        ) : (
-          <div class="lds-dual-ring">
-            <div></div>
-          </div>
-        )}
-        {cachedState.inProgress ? (
-          <>
             <div className="instruction-box">
               <h1 value={cachedState}>
                 Step {cachedState.currStep + 1} of {cachedState.moves.length}:
@@ -105,14 +97,10 @@ export default function DockView ({ cachedState, setCachedState }) {
                   Write a comment in the log
                 </button>
               </div>
-            </div>
-          </>
-        ) : (
-          <div class="lds-dual-ring">
-            <div></div>
           </div>
+          </div> 
+        ) : (
+          <Loading displayText={"Sit tight! We're currently calculating the best moveset..."} /> 
         )}
-      </div>
-    </div>
-  );
-}
+    </div> 
+)};

--- a/src/components/DockView.js
+++ b/src/components/DockView.js
@@ -4,13 +4,13 @@ import {
   runAstar,
   runMove,
   handleCustomLog,
+  skipMove,
 } from "./BackendRoutes";
 import Grid from "./Grid";
 import LogoutButton from "./LogoutButton";
 
 export default function DockView ({ cachedState, setCachedState }) {
   const nav = useNavigate(); 
-
   // probably don't need these but will clean up later once i figure out skipmove
   const cargoState = useRef(false); 
   const currentCargoState = useRef(cachedState.manifest); 
@@ -30,183 +30,16 @@ export default function DockView ({ cachedState, setCachedState }) {
   const isBalance = cachedState.opType === 'Offloading/Onloading' ? false : true; 
 
 
-  // ------------------------------ flask backend functions -------------------------------------
-
-
-  // runs astar - only to be called at the beginning of ops or when the move is skipped
-  
-  // const runAstar = async () => {
-  //   console.log("DOCKVIEW: called astar")
-  //   const isBalance = cachedState.opType === 'Offloading/Onloading' ? false : true; 
-  //     const aStarRes = await handleRunAstar(
-  //       localStorage.getItem('manifest'),
-  //       isBalance,
-  //       cachedState.offloadList,
-  //       cachedState.loadList
-  //     ).catch(err => console.log(err.message))
-  //     .then(result => {
-  //       console.log("DOCKVIEW.JS: runastar completed")
-  //       moveList.current = result.moves; 
-  //     }); 
-  //     console.log("DOCKVIEW.JS: result ", moveList.current); 
-  //     if (moveList.current.length !== 0) {
-  //       let mvs = moveList.current; 
-  //       setCachedState({
-  //         ...cachedState, 
-  //         inProgress: true, 
-  //         moves: mvs, // saves as an object?  
-  //         totalSteps: mvs.length
-  //       }); 
-
-  //       // save in ref - we set here so we don't have to refresh as much 
-  //       const nextMove = mvs.shift(); 
-  //       currMove.current = nextMove; 
-  //       moveList.current = mvs; 
-  //       // const currarea = mapArea(nextMove['current-area']); 
-  //       // const nextarea = mapArea(nextMove['next-area']); 
-  //       // currMove.current = {
-  //       //   ...currMove.current, 
-  //       //   'current-area': currarea, 
-  //       //   'next-area': nextarea
-  //       // }
-  //       console.log("CURRMOVE: ", currMove.current); 
-       
-  //     }
-  //     // Perform any actions based on the response from handleRunAstar
-  //     // console.log('A* Algorithm solution:', astarResult.solution)
-  //     // console.log('A* Algorithm moves:', astarResult.moves)
-  // }; 
-  
-
- 
-  
-  // const runMove = async move => {
-  //   await runMove(move).catch(err => console.log(err))
-  //   .then(async (response) => {
-  //     console.log("DOCKVIEW.JS: handleRunMove completed")
-  //     console.log(response)
-  //     const dict = await handleGetCurrentCargoState().catch(err => console.log(err))
-  //     .then((response) => {
-  //       // console.log("DOCKVIEW.JS RESPONSE FROM RUNMOVE: ", response);
-  //       currentBufferState.current = response.buffer
-  //       currentCargoState.current = response.ship
-  //       console.log("DOCKVIEW.JS: getCurrentCargoState completed")
-  //     }); 
-  //   });
-
-  //   if (moveList.current.length !== 0) {
-  //     let mvs = moveList.current; 
-
-  //     // save in ref - we set here so we don't have to refresh as much 
-  //     const nextMove = mvs.shift(); 
-  //     currMove.current = nextMove; 
-  //     moveList.current = mvs; 
-
-  //     console.log("RUNMOVE CURRMOVE: ", currMove.current); 
-
-  //     //sanity check 
-  //     setCachedState({
-  //       ...cachedState, 
-  //       inProgress: true, 
-  //       moves: mvs, // saves as an object?  
-  //       currStep: cachedState.currStep + 1
-  //     }); 
-  //   } else { // we're done with moves. fin 
-  //     setCachedState({inProgress: false}); 
-  //     nav('/home'); 
-
-  //   }
-  // };
-
-  // assumption: current cargo state is being updated with every call to make move.
-  
-  // const skipMove = async move => {
-  //   if (cachedState.opType === "Offloading/Onloading") {
-  //     if (move['current-area'] < move['next-area']) { // offload operation - we check offload list
-  //       let name = move['name']
-  //       let newOffload = cachedState.offloadList
-  //       let idx = cachedState.offloadList.indexOf(name); 
-  //       newOffload.splice(idx, 1)
-  //       setCachedState({
-  //         ...cachedState, 
-  //         offloadList: newOffload
-  //       }); 
-  //     } else { // we check onload list - onload includes weight 
-  //       const name = move['name']
-  //       const weight = move['weight'].toString()
-  //       let newOnload = cachedState.loadList; 
-  //       for (let i = 0; i < newOnload.length; i=i+2) { 
-  //         if (newOnload[i] === name && newOnload[i+1] === weight) { 
-  //           newOnload.splice(i, 2)
-  //         }
-  //       }
-  //       setCachedState({
-  //         ...cachedState, 
-  //         loadList: newOnload, 
-  //         currStep: cachedState.currStep + 1
-  //       }); 
-  //       if (cachedState.currStep === cachedState.totalSteps) {
-  //         setCachedState({inProgress: false}); 
-  //         nav('/home')
-  //       }
-
-  //     }
-  //   }
-
-  //   await handleGetManifest().catch(e => console.log(e))
-  //   .then(async (response) => {
-  //     // may need to update this to setCache then parsemanifest file we shall see.
-  //     localStorage.setItem('manifest', response)
-  //     await runAstar().catch(e => console.log(e)).then(() => {
-  //       console.log("handleGetManifest: astar successfully fetched")
-  //     }); 
-  //   })
-
-    
-  // }; 
-  
-
-
-  // ------------------------------ end flask backend functions -------------------------------------
-
   const BUFFER = "buffer";
   const SHIP = "ship";
 
-  
-  // useEffect(() => {
-  //   console.log("dockView...");
-  //   if (cargoState.current === false) {
-  //     // cargo state has not been initialized yet
-  //     //createCargoState();
-  //     handleCreateCargoState(
-  //       localStorage.getItem("manifest"),
-  //       cachedState.offloadList,
-  //       cachedState.loadList
-  //     )
-  //     cargoState.current = true;
-  //     handleRunAstar();
-  //   }
-  //   console.log("CURRMOVE: ", currMove.current);
-  //   // console.log(cargoState.current);
-  //   // if (cachedState.moves.length !== 0) {
-  //   //   let currmoves = cachedState.moves;
-  //   //   const nextMove = currmoves.shift();
-  //   //   const currarea = mapArea(nextMove['current-area']);
-  //   //   const nextarea = mapArea(nextMove['next-area']);
-  //   //   currMove.current = {
-  //   //     ...nextMove,
-  //   //     'current-area': currarea,
-  //   //     'next-area': nextarea
-  //   //   }
-  //   //   setCachedState({
-  //   //     ...cachedState,
-  //   //     inProgress: true,
-  //   //     moves: currmoves
-  //   //   });
-  //   // }
-  // }, [cachedState, currMove.current, moveList.current, goalCargoState]);
 
-  
+
+  const triggerSkipMove = () => {
+    skipMove(cachedState, setCachedState); 
+    
+  }
+
 
   // runs a star if there wasnt already an operation in progress and cargostate has already been initialized (cachedState.buffer)
   useEffect(() => {
@@ -218,7 +51,7 @@ export default function DockView ({ cachedState, setCachedState }) {
   // useEffect that handles when u finish and generates the instruction every time we make a move (currStep changes)
   useEffect(() => {
     if (cachedState.inProgress === true) {
-      if (cachedState.currStep === cachedState.moves.length && cachedState.currStep != 0) {
+      if (cachedState.currStep === cachedState.moves.length && cachedState.currStep != 0 || cachedState.moves.length === 0) {
         nav("/finish");
       }
     }
@@ -260,7 +93,7 @@ export default function DockView ({ cachedState, setCachedState }) {
                   Make Move
                 </button>
                 <button
-                  onClick={() => runMove(cachedState, setCachedState)}
+                  onClick={() => skipMove(cachedState, setCachedState)}
                   className="primary-submit-btn"
                 >
                   Skip Move

--- a/src/components/DockView.js
+++ b/src/components/DockView.js
@@ -5,7 +5,6 @@ import {
   runMove,
   handleCustomLog,
   skipMove,
-  skipMove2,
 } from "./BackendRoutes";
 import Loading from "./Loading"; 
 import Grid from "./Grid";
@@ -82,8 +81,7 @@ export default function DockView ({ cachedState, setCachedState }) {
                 </button>
                 <button
                   onClick={() => {
-                    //setCachedState({...cachedState, inProgress: false})
-                    skipMove2(cachedState, setCachedState)}}
+                    skipMove(cachedState, setCachedState)}}
                   className="primary-submit-btn"
                 >
                   Skip Move

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,0 +1,32 @@
+import "../css/Loading.css"; 
+
+// source: https://codepen.io/austinmzach/pen/nPJOBO 
+const Loading = ({ displayText, redirectPath }) => { 
+    // displayText: show something to users if they want 
+    // redirectPath: where it should redirect users to once finished rendering (if applicable - might just use if/else statement in code)
+
+    return ( 
+        <div className="loading"> 
+        <span>l</span>
+        <span>o</span>
+        <span>a</span>
+        <span>d</span>
+        <span>i</span>
+        <span>n</span>
+        <span>g</span>
+        <div className="hidden">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+        </div>
+        </div> 
+    )
+
+
+}
+
+export default Loading; 

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,19 +1,18 @@
 import "../css/Loading.css"; 
 
-// source: https://codepen.io/austinmzach/pen/nPJOBO 
-const Loading = ({ displayText, redirectPath }) => { 
+const Loading = ({ displayText }) => { 
     // displayText: show something to users if they want 
-    // redirectPath: where it should redirect users to once finished rendering (if applicable - might just use if/else statement in code)
 
     return ( 
+        <div> 
         <div className="loading"> 
-        <span>l</span>
-        <span>o</span>
-        <span>a</span>
-        <span>d</span>
-        <span>i</span>
-        <span>n</span>
-        <span>g</span>
+        <span style={{backgroundColor: '#005F73'}}>L</span>
+        <span style={{backgroundColor: '#0A9396'}}>O</span>
+        <span style={{backgroundColor: '#94D2BD'}}>A</span>
+        <span style={{backgroundColor: '#EE9B00'}}>D</span>
+        <span style={{backgroundColor: '#CA6702'}}>I</span>
+        <span style={{backgroundColor: '#BB3E03'}}>N</span>
+        <span style={{backgroundColor: '#AE2012'}}>G</span>
         <div className="hidden">
             <span></span>
             <span></span>
@@ -23,6 +22,8 @@ const Loading = ({ displayText, redirectPath }) => {
             <span></span>
             <span></span>
         </div>
+        </div> 
+            <h1>{displayText}</h1>
         </div> 
     )
 

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -4,23 +4,23 @@ const Loading = ({ displayText }) => {
     // displayText: show something to users if they want 
 
     return ( 
-        <div> 
+        <div className="load-container"> 
         <div className="loading"> 
-        <span style={{backgroundColor: '#005F73'}}>L</span>
-        <span style={{backgroundColor: '#0A9396'}}>O</span>
-        <span style={{backgroundColor: '#94D2BD'}}>A</span>
-        <span style={{backgroundColor: '#EE9B00'}}>D</span>
-        <span style={{backgroundColor: '#CA6702'}}>I</span>
-        <span style={{backgroundColor: '#BB3E03'}}>N</span>
-        <span style={{backgroundColor: '#AE2012'}}>G</span>
+        <span style={{backgroundColor: '#005F73'}} className="span-st">L</span>
+        <span style={{backgroundColor: '#0A9396'}} className="span-st">O</span>
+        <span style={{backgroundColor: '#94D2BD'}} className="span-st">A</span>
+        <span style={{backgroundColor: '#EE9B00'}} className="span-st">D</span>
+        <span style={{backgroundColor: '#CA6702'}} className="span-st">I</span>
+        <span style={{backgroundColor: '#BB3E03'}} className="span-st">N</span>
+        <span style={{backgroundColor: '#AE2012'}} className="span-st">G</span>
         <div className="hidden">
-            <span></span>
-            <span></span>
-            <span></span>
-            <span></span>
-            <span></span>
-            <span></span>
-            <span></span>
+            <span className="span-st"></span>
+            <span className="span-st"></span>
+            <span className="span-st"></span>
+            <span className="span-st"></span>
+            <span className="span-st"></span>
+            <span className="span-st"></span>
+            <span className="span-st"></span>
         </div>
         </div> 
             <h1>{displayText}</h1>

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,4 +1,5 @@
 import "../css/Loading.css"; 
+import { useState } from 'react'; 
 
 const Loading = ({ displayText }) => { 
     // displayText: show something to users if they want 

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,7 +1,7 @@
 import handleTimestamp from './Timestamp'
 import { useNavigate } from 'react-router-dom'
 import React, { useState } from 'react'
-import { handleLogMessage } from './BackendRoutes'
+import { handleLogMessage } from './BackendRoutes'; 
 
 // assumption: if we logout, we are clearing all the user data 
 function Login ({ cachedState, setCachedState }) {

--- a/src/css/Loading.css
+++ b/src/css/Loading.css
@@ -1,0 +1,63 @@
+@import url("https://fonts.googleapis.com/css2?family=Raleway&family=Roboto:wght@100;300&display=swap");
+
+* {
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+body {
+  padding-top: 10em;
+  text-align: center;
+}
+
+.loading {
+  position: relative;
+  margin: auto;
+  width: 350px;
+  color: white;
+  font-family: "Raleway", sans-serif;
+  font-size: 250%;
+}
+
+.loading:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+span {
+  float: left;
+  height: 100px;
+  line-height: 120px;
+  width: 50px;
+}
+
+.loading > span {
+  border-left: 1px solid #444;
+  border-right: 1px solid #222;
+}
+
+.hidden {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+}
+
+.hidden span {
+  background: linear-gradient(180deg, white 0, #ddd 100%);
+  animation: up 2s infinite;
+}
+
+@keyframes up {
+  0%   { margin-bottom: 0; }
+  16%  { margin-bottom: 100%; height: 20px; }
+  50% { margin-bottom: 0; }
+  100% { margin-bottom: 0; }
+}
+
+.hidden span:nth-child(2) { animation-delay: .142857s; }
+.hidden span:nth-child(3) { animation-delay: .285714s; }
+.hidden span:nth-child(4) { animation-delay: .428571s; }
+.hidden span:nth-child(5) { animation-delay: .571428s; }
+.hidden span:nth-child(6) { animation-delay: .714285s; }
+.hidden span:nth-child(7) { animation-delay: .857142s; }

--- a/src/css/Loading.css
+++ b/src/css/Loading.css
@@ -2,7 +2,6 @@
 
 * {
   box-sizing: border-box;
-  overflow: hidden;
 }
 
 body {
@@ -15,6 +14,8 @@ body {
   margin: auto;
   width: 350px;
   color: white;
+  text-shadow: 3.35px 0px  #E9D8A6;
+  font-weight: bolder;
   font-family: "Raleway", sans-serif;
   font-size: 250%;
 }
@@ -24,6 +25,11 @@ body {
   display: table;
   clear: both;
 }
+h1 { 
+  font-family: 'Raleway'; 
+  font-size: 2em; 
+}
+
 
 span {
   float: left;
@@ -32,10 +38,7 @@ span {
   width: 50px;
 }
 
-.loading > span {
-  border-left: 1px solid #444;
-  border-right: 1px solid #222;
-}
+
 
 .hidden {
   position: absolute;

--- a/src/css/Loading.css
+++ b/src/css/Loading.css
@@ -4,7 +4,7 @@
   box-sizing: border-box;
 }
 
-body {
+.load-container {
   padding-top: 10em;
   text-align: center;
 }
@@ -31,7 +31,7 @@ h1 {
 }
 
 
-span {
+.span-st {
   float: left;
   height: 100px;
   line-height: 120px;


### PR DESCRIPTION
**_purpose:_** Skip move and little loading graphic component to display in between calculating the moves. 

_**files changes:**_
 
1. _app.py:_
- added the skip move endpoint in backend which is basically a combination of run_astar and run_move. could be a bit redundant, i was just afraid of messing stuff up 
- deletes the move from the cargo state and passes current_cargo_state back into run_astar, and generates a new moveset.
- also made small change in run_move so that the data type is consistent, and it still stores the weight/name for the load list in cachedState (previously it was just the name). we need this later for run_move and also making sure that we delete the right move as well. 

2. _backendRoutes.js:_ 
- much like app.py, combines run_move and run_astar together. we make the request and update the cached state with the new moveset. 

3. _defaultState.js:_
- changed moves to null instead of an empty array. we do this so that for the if/else block seen in DockView.js 

4. _DockView.js:_
- got rid of a bunch of redundant code since we're not using it anymore 
- created an if/else block that displays the loading page if moves and the buffer is not null in the JSX return portion.... honestly could just check for the moves, if the moves are loaded, then buffer/ship view is certain to also be loaded 
- added triggerSkipMove which just calls the backend. was just thinking that it should also maybe set moves to null in cachedState so it re-renders to show the loading page. 

5. _Loading.js/Loading.css:_
- just a little loading animation. i think it's cool. 